### PR TITLE
Enable access to the host from the guest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,13 @@ credentials:
   # Default: No server.
   # May be overridden from the command-line with parameter `--server`.
 ```
+
+# Docker notes
+
+Everything is executed with Docker, with the same limitations and abstraction leaks.
+
+Host `host.docker.internal` should be configured on all platforms, which gives the guest Synapse (and modules) access to the host, should this be needed for tests.
+
+The guest container is running on a network called `mx-tester-synapse-$(TAG)`,
+where `TAG` is the Docker tag for the version of Synapse running. By default,
+that's `matrixdotorg/synapse:latest`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,6 +860,11 @@ EXPOSE 8008/tcp 8009/tcp 8448/tcp
                 t: config.tag(),
                 q: true,
                 rm: true,
+                // Enable access to host as `host.docker.internal` from the guest.
+                // On macOS and Windows, this is expected to be transparent but
+                // on Linux, an option needs to be added.
+                #[cfg(target_os = "linux")]
+                extrahosts: Some("host.docker.internal:host-gateway".to_string()),
                 ..Default::default()
             },
             config.credentials.serveraddress.as_ref().map(|server| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,11 @@ async fn start_synapse_container(
                         )]),
                         // Expose guest port `guest_mapping` as `host_mapping`.
                         port_bindings: Some(host_port_bindings),
+                        // Enable access to host as `host.docker.internal` from the guest.
+                        // On macOS and Windows, this is expected to be transparent but
+                        // on Linux, an option needs to be added.
+                        #[cfg(target_os = "linux")]
+                        extra_hosts: Some(vec!["host.docker.internal:host-gateway".to_string()]),
                         ..HostConfig::default()
                     }),
                     image: Some(config.tag()),
@@ -860,11 +865,6 @@ EXPOSE 8008/tcp 8009/tcp 8448/tcp
                 t: config.tag(),
                 q: true,
                 rm: true,
-                // Enable access to host as `host.docker.internal` from the guest.
-                // On macOS and Windows, this is expected to be transparent but
-                // on Linux, an option needs to be added.
-                #[cfg(target_os = "linux")]
-                extrahosts: Some("host.docker.internal:host-gateway".to_string()),
                 ..Default::default()
             },
             config.credentials.serveraddress.as_ref().map(|server| {


### PR DESCRIPTION
This should help with a number of tests that need to talk across guest/host borders.