### PR TITLE
New configuration options for modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "mx-tester"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mx-tester"
 description = "A tool to help test Matrix bots and Synapse modules."
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/matrix-org/mx-tester"


### PR DESCRIPTION
This adds two new configuration options for modules:

1. `env` lets a module configure the guest environment (useful e.g. for setting up a `PATH`);
2. `copy` lets a module place additional files in the guest environment (useful e.g. for copying resource files).